### PR TITLE
Update advanced.rst

### DIFF
--- a/source/advanced.rst
+++ b/source/advanced.rst
@@ -945,9 +945,9 @@ The design contains two event classes *CustomerMovedEvent* and *CustomerMovedAbr
 .. code-block:: c#
 
     // Configuration
-    container.RegisterManyForOpenGeneric(typeof(IValidator<>),
+    container.RegisterManyForOpenGeneric(typeof(IEventHandler<>),
         container.RegisterAll,
-        typeof(IValidator<>).Assembly);
+        typeof(IEventHandler<>).Assembly);
 
     // Usage
     var handlers = container.GetAllInstances<IEventHandler<CustomerMovedAbroadEvent>>();


### PR DESCRIPTION
The call to container.RegisterManyForOpenGeneric contained IValidator which is probably the result of a copy paste action, which needed modification for the given example