### PR TITLE
Adds MVC configuration to the example

### DIFF
--- a/source/aspnetintegration.rst
+++ b/source/aspnetintegration.rst
@@ -31,6 +31,8 @@ The following code snippet shows how to use the integration package to apply Sim
         // This method gets called by the runtime.
         public void ConfigureServices(IServiceCollection services) {
             // ASP.NET default stuff here
+            
+            services.AddMvc();
 
             services.AddSingleton<IControllerActivator>(
                 new SimpleInjectorControllerActivator(container));
@@ -54,6 +56,14 @@ The following code snippet shows how to use the integration package to apply Sim
             // Add custom middleware
             app.Use(async (context, next) => {
                 await container.GetInstance<CustomMiddleware>().Invoke(context, next);
+            });
+            
+            // Add Mvc Routes
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute(
+                    name: "default",
+                    template: "{controller=Home}/{action=Index}/{id?}");
             });
 
             // ASP.NET default stuff here


### PR DESCRIPTION
Example is confusing without since the example includes configuring simple injector for MVC Core but doesn't include the required aspnet core mvc configuration to make it work. simpleinjector/SimpleInjector#391