### PR TITLE
Winforms example is broken

### DIFF
--- a/source/windowsformsintegration.rst
+++ b/source/windowsformsintegration.rst
@@ -31,7 +31,7 @@ The following code snippet is an example of how to register Simple Injector cont
             // Register your types, for instance:
             container.Register<IUserRepository, SqlUserRepository>(Lifestyle.Singleton);
             container.Register<IUserContext, WinFormsUserContext>();
-            container.Register<Form1>();    
+            container.RegisterSingleton<Form1>();    
 
             // Optionally verify the container.
             container.Verify();


### PR DESCRIPTION
Registering an IDisposable as Transient leads to a warning at verification.
Form registered as singleton will clear the warning : https://stackoverflow.com/q/33555088/444469