### PR TITLE
Update wpfintegration.rst

### DIFF
--- a/source/wpfintegration.rst
+++ b/source/wpfintegration.rst
@@ -61,6 +61,7 @@ Add a *Program.cs* file to your project to be the new entry point for the applic
         private static void RunApplication(Container container) {
             try {
                 var app = new App();
+                app.InitializeComponent();
                 var mainWindow = container.GetInstance<MainWindow>();
                 app.Run(mainWindow);
             } catch (Exception ex) {


### PR DESCRIPTION
I followed the documentation to start using simpleinjector in my wpf application. I ran into a problem where the resources I added in App.xaml were not being applied in MainWindow (Realized this when trying to use https://mahapps.com/guides/quick-start.html). To fix this it was necessary to add a call to InitializeComponent on the App object. I have updated the documentation with a call to app.InitializeComponent()