### PR TITLE
Explicitly mention calling CrossWire

### DIFF
--- a/source/aspnetintegration.rst
+++ b/source/aspnetintegration.rst
@@ -461,7 +461,7 @@ The **AddAspNetCore** method contains an overload that accepts an **ServiceScope
 Working with ASP.NET Core Identity
 ==================================
 
-The default Visual Studio template comes with built-in authentication through the use of ASP.NET Core Identity. The default template requires a fair amount of cross-wired dependencies. When auto cross wiring is enabled (when calling **AddSimpleInjector**) integration with ASP.NET Core Identity couldn't be more straightforward. When you followed the :ref:`cross wire guidelines <cross-wiring>`, this is all you'll have to do to get Identity running.
+The default Visual Studio template comes with built-in authentication through the use of ASP.NET Core Identity. The default template requires a fair amount of cross-wired dependencies. When auto cross wiring is enabled (when calling **AddSimpleInjector** and **CrossWire**) integration with ASP.NET Core Identity couldn't be more straightforward. When you followed the :ref:`cross wire guidelines <cross-wiring>`, this is all you'll have to do to get Identity running.
 
 .. container:: Note
 


### PR DESCRIPTION
The documentation lead me to believe calling `AddSimpleInjector` was sufficient to perform cross-wiring. But I also need to explicitly call `CrossWire` for each service I want to cross-wire. This is explained in detail in the referenced article, but this one line is somewhat misleading in my humble opinion.