### PR TITLE
Make users aware of OnePerNestedScope requirement

### DIFF
--- a/source/blazorintegration.rst
+++ b/source/blazorintegration.rst
@@ -130,6 +130,9 @@ To integrate Simple Injector with Blazor, please follow the following steps:
 
             services.AddSimpleInjector(container, options =>
             {
+                // If you plan on adding AspNetCore as well, change the ServiceScopeReuseBehavior to OnePerNestedScope.
+                // options.AddAspNetCore(ServiceScopeReuseBehavior.OnePerNestedScope);
+
                 options.AddServerSideBlazor(this.GetType().Assembly);
             });
 


### PR DESCRIPTION
I recently spend a great amount of time to debug an issue where framework dependencies injected by SimpleInjector would not be correctly instantiated. Eventually [I discovered](https://github.com/simpleinjector/SimpleInjector/issues/676#issuecomment-985429715) that I needed to change the default to `OnePerNestedScope`, but finding this out was non-trivial. I think it would be good to point out to users that they need to change the default if they wish to combine AspNetCore with Blazor.