### PR TITLE
removing app.InitializeComponent()

### DIFF
--- a/source/wpfintegration.rst
+++ b/source/wpfintegration.rst
@@ -65,7 +65,6 @@ Add a *Program.cs* file to your project to be the new entry point for the applic
             try
             {
                 var app = new App();
-                app.InitializeComponent();
                 var mainWindow = container.GetInstance<MainWindow>();
                 app.Run(mainWindow);
             }


### PR DESCRIPTION
Looks like WPF (at least .net core 6 version) doesn't implement InitializeComponent() method in App.

![image](https://user-images.githubusercontent.com/54535207/178558007-b64cd076-c21f-44d9-bf2f-b9ba78d3532b.png)

If this line is present, the project will not compile, however if removed there are no side effects (everything runs as expected).